### PR TITLE
brew: Remove deprecated bottle :unneeded

### DIFF
--- a/Formula/cosign.rb
+++ b/Formula/cosign.rb
@@ -7,7 +7,6 @@ class Cosign < Formula
   version "1.2.0"
   license "Apache-2.0"
   head "https://github.com/sigstore/cosign.git"
-  bottle :unneeded
 
   on_macos do
     depends_on "pcsc-lite"

--- a/Formula/rekor-cli.rb
+++ b/Formula/rekor-cli.rb
@@ -7,7 +7,6 @@ class RekorCli < Formula
   version "0.3.0"
   license "Apache-2.0"
   head "https://github.com/sigstore/rekor.git"
-  bottle :unneeded
 
   on_macos do
     if Hardware::CPU.intel?


### PR DESCRIPTION
#### Summary
Remove bottle `:unneeded` from brew formula

bottle `:unneeded` now provokes a warning from Homebrew:
`Warning: Calling bottle :unneeded is deprecated! There is no replacement.`

Homebrew apparently deprecated `bottle :unneeded` in https://github.com/Homebrew/brew/commit/f65d525693a45c8e4c2ebc1452080f08c363ee15

#### Ticket Link
n/a

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->
```release-note
brew: Remove deprecated bottle :unneeded
```
