### PR TITLE
upgrade cosign tap to v1.3.1

### DIFF
--- a/Formula/cosign.rb
+++ b/Formula/cosign.rb
@@ -4,7 +4,7 @@
 class Cosign < Formula
   desc "Container Signing, Verification and Storage in an OCI registry"
   homepage "https://sigstore.dev"
-  version "1.3.0"
+  version "1.3.1"
   license "Apache-2.0"
   head "https://github.com/sigstore/cosign.git"
 
@@ -13,24 +13,24 @@ class Cosign < Formula
 
     if Hardware::CPU.intel?
       url "https://github.com/sigstore/cosign/releases/download/v#{version}/cosign-darwin-amd64"
-      sha256 "bf8423700e8bbf01f03769f7b4bd078a4c8527ce98c28cd4c9bf2f83144e9485"
+      sha256 "bcffa19e80f3e94d70e1fb1b0f591b0dec08926b31d3609fe3d25a1cc0389a0a"
     end
 
     if Hardware::CPU.arm?
       url "https://github.com/sigstore/cosign/releases/download/v#{version}/cosign-darwin-arm64"
-      sha256 "5c204f0a8543d695e4037d090d3dc1f97c26ffae67b8740c4b4098ad2cca4abd"
+      sha256 "eda58f090d8f4f1db5a0e3a0d2d8845626181fe8aa1cea1791e0afa87fee7b5c"
     end
   end
 
   on_linux do
     if Hardware::CPU.intel?
       url "https://github.com/sigstore/cosign/releases/download/v#{version}/cosign-linux-amd64"
-      sha256 "9604a5eb171748113f92a67495556007dde6f45804f0b38d3e55c3bc7e151774"
+      sha256 "1227b270e5d7d21d09469253cce17b72a14f6b7c9036dfc09698c853b31e8fc8"
     end
 
     if Hardware::CPU.arm?
       url "https://github.com/sigstore/cosign/releases/download/v#{version}/cosign-linux-arm64"
-      sha256 "87675ea2a887b0817a6d9f9b8b1ed4a46633d2b0574cc284d3e58ab2c1546277"
+      sha256 "165d09dda794b6aee21585b5158b42fdef07b81ce57cae2915e870de6fe600e2"
     end
   end
 


### PR DESCRIPTION
#### Summary
- upgrade cosign tap to v1.3.1

#### Ticket Link
n/a

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->
```release-note
upgrade cosign tap to v1.3.1
```
